### PR TITLE
Fixes issue with Explicitness naming

### DIFF
--- a/Chapter 4/Music Store.playground/Sources/Explicitness.swift
+++ b/Chapter 4/Music Store.playground/Sources/Explicitness.swift
@@ -7,7 +7,7 @@ public enum Explicitness: String, Decodable {
     case explicit
     
     /// Cleaned version with explicit lyrics "bleeped out"
-    case clean
+    case cleaned
     
     /// No explicit lyrics
     case notExplicit


### PR DESCRIPTION
"clean" should be "cleaned" in the iTunes API results. Fixes issue with exception when unpacking fails.